### PR TITLE
biger delay if runing under composite wm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 escrotum.egg-info
+build/
+dist/

--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -183,7 +183,11 @@ class Escrotum(gtk.Window):
 
             self.ungrab()
             self.hide()
-            gobject.timeout_add(100, self.screenshot)
+            tout = 100
+            if self.get_screen().is_composited():
+                tout = 1300
+            gtk.gdk.flush()
+            gobject.timeout_add(tout, self.screenshot)
         else:
             gtk.main_do_event(event)
 


### PR DESCRIPTION
compton draws shadow under grab window, and keeps it for some time
after grab window is closed. So lets wait more time to let compton
completely remove shadow before taking screenshot.