### PR TITLE
Save file even if clipboard option is specified

### DIFF
--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -263,10 +263,9 @@ class Escrotum(gtk.Window):
         if not pb:
             print "Invalid Pixbuf"
             exit(EXIT_INVALID_PIXBUF)
+        self.save_file(pb, width, height)
         if self.use_clipboard:
             self.save_clipboard(pb)
-        else:
-            self.save_file(pb, width, height)
         if self.command:
             self.call_exec(width, height)
 


### PR DESCRIPTION
Hi there! Awesome tool.

With `scrot` and the `-e` option I was able to take a screenshot, save the file and also copy it to the cliboard like this:

```
scrot -s 'screenshot_%Y%m%d_%H%M%S.png' -e 'mkdir -p ~/Pictures/screenshots && mv $f ~/Pictures/screenshots && xclip -selection clipboard -t image/png -i ~/Pictures/screenshots/`ls -1 -t ~/Pictures/screenshots | head -1`'
```

I would like to do the same with `escrotum` but I can't because there's no `-e` option (althought there's some code for it in `main.py`?) and because specifying `-C` stops the program from saving the file.

These changes make it so that specifying `-C` will also save the file anyway, I think this is better functionality. Maybe we could add another flag for it?