### PR TITLE
Convert to python 3 using 2to3

### DIFF
--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import os
 import sys
@@ -10,7 +10,7 @@ import gtk
 import cairo
 import gobject
 
-from utils import get_selected_window, daemonize, bgra2rgba
+from .utils import get_selected_window, daemonize, bgra2rgba
 
 
 __version__ = "0.2.1"
@@ -84,7 +84,7 @@ class Escrotum(gtk.Window):
                 sys.stdout.flush()
             return True
         if self.delay == 0 and self.countdown:
-            print "."
+            print(".")
 
         if self.selection and not self.xid:
             self.grab()
@@ -139,7 +139,7 @@ class Escrotum(gtk.Window):
                                       cursor=gtk.gdk.Cursor(gtk.gdk.CROSSHAIR))
 
         if status != gtk.gdk.GRAB_SUCCESS:
-            print "Can't grab the mouse"
+            print("Can't grab the mouse")
             exit(EXIT_CANT_GRAB_MOUSE)
         gtk.gdk.event_handler_set(self.event_handler)
 
@@ -166,7 +166,7 @@ class Escrotum(gtk.Window):
 
         if event.type == gtk.gdk.BUTTON_PRESS:
             if event.button != 1:
-                print "Canceled by the user"
+                print("Canceled by the user")
                 exit(EXIT_CANCEL)
             # grab the keyboard only when selection started
             gtk.gdk.keyboard_grab(self.root)
@@ -177,7 +177,7 @@ class Escrotum(gtk.Window):
 
         elif event.type == gtk.gdk.KEY_RELEASE:
             if gtk.gdk.keyval_name(event.keyval) == "Escape":
-                print "Canceled by the user"
+                print("Canceled by the user")
                 exit(EXIT_CANCEL)
 
         elif event.type == gtk.gdk.MOTION_NOTIFY:
@@ -243,7 +243,7 @@ class Escrotum(gtk.Window):
         if self.click_selection:
             xid = get_selected_window()
             if not xid:
-                print "Can't get the xid of the selected window"
+                print("Can't get the xid of the selected window")
                 exit(EXIT_XID_ERROR)
             selected_window = gtk.gdk.window_foreign_new(xid)
             width, height = selected_window.get_size()
@@ -261,7 +261,7 @@ class Escrotum(gtk.Window):
         pb2.copy_area(x, y, width, height, pb, 0, 0)
 
         if not pb:
-            print "Invalid Pixbuf"
+            print("Invalid Pixbuf")
             exit(EXIT_INVALID_PIXBUF)
         if self.use_clipboard:
             self.save_clipboard(pb)
@@ -368,9 +368,9 @@ class Escrotum(gtk.Window):
 
         try:
             pb.save(self.filename, filetype)
-            print self.filename
-        except Exception, error:
-            print error
+            print(self.filename)
+        except Exception as error:
+            print(error)
             exit(EXIT_CANT_SAVE_IMAGE)
 
     def call_exec(self, width, height):
@@ -478,7 +478,7 @@ def run():
         exit()
 
     if args.countdown and not args.delay:
-        print "Countdown parameter requires delay"
+        print("Countdown parameter requires delay")
         exit()
 
     Escrotum(filename=args.FILENAME, selection=args.select, xid=args.xid,
@@ -489,7 +489,7 @@ def run():
     try:
         gtk.main()
     except KeyboardInterrupt:
-        print "Canceled by the user"
+        print("Canceled by the user")
         exit(EXIT_CANCEL)
 
 if __name__ == "__main__":

--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -6,6 +6,10 @@ import datetime
 import subprocess
 import argparse
 
+from gi import pygtkcompat
+pygtkcompat.enable()
+pygtkcompat.enable_gtk(version='3.0')
+
 import gtk
 import cairo
 import gobject

--- a/escrotum/utils.py
+++ b/escrotum/utils.py
@@ -52,7 +52,7 @@ def daemonize():
         if pid > 0:
             # exit first parent
             sys.exit(0)
-    except OSError, e:
+    except OSError as e:
         sys.stderr.write("fork #1 failed: %d (%s)\n" % (e.errno, e.strerror))
         sys.exit(1)
 
@@ -67,7 +67,7 @@ def daemonize():
         if pid > 0:
             # exit from second parent
             sys.exit(0)
-    except OSError, e:
+    except OSError as e:
         sys.stderr.write("fork #2 failed: %d (%s)\n" % (e.errno, e.strerror))
         sys.exit(1)
 


### PR DESCRIPTION
Hello, I tried to convert the codebase from python2 to python3 using [2to3](https://docs.python.org/3.0/library/2to3.html), looks like everything is working after the change.
This should fix #46 