### PR TITLE
setup.py: Change gobject reference to PyGObject

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-      'gobject',
+      'PyGObject',
       'xcffib',
     ],
     entry_points={


### PR DESCRIPTION
python3 gobject's egg-info says we should use PyGObject as our install dependencies in setup.py. Changing it makes this work with python 3. 