### PR TITLE
util.py: Fix deprecated 'c' array construct

### DIFF
--- a/escrotum/util.py
+++ b/escrotum/util.py
@@ -108,7 +108,7 @@ def bgra2rgba(pixels, width, height):
         arr.shape = (-1, 4)
         data = arr[:,[2,1,0,3]]
     else:
-        data = array.array ("c", pixels)
+        data = array.array ('B', pixels)
         for x in range (width):
             for y in range (height):
                 i = (width * y + x) * 4


### PR DESCRIPTION
The 'c' array construct has been deprecated since python 2.6 and this will throw a ValueError on python 3 if numpy is not found. This patch changes it to unsigned bytes, since that's really what we want here. 