### PR TITLE
Fix #59: Selection captures wrong area

### DIFF
--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -290,7 +290,7 @@ class Escrotum(gtk.Dialog):
         root_width, root_height = window.get_width(), window.get_height()
         pb2 = Pixbuf.Pixbuf.new(Pixbuf.Colorspace.RGB, True, 8,
                                 root_width, root_height)
-        pb2 = gdk.pixbuf_get_from_window(window, x, y, width, height)
+        pb2 = gdk.pixbuf_get_from_window(window, 0, 0, root_width, root_height)
         pb2 = self.mask_pixbuf(pb2, root_width, root_height)
         pb2.copy_area(x, y, width, height, pb, 0, 0)
 


### PR DESCRIPTION
Previously just the selected area was copied into the buffer that should contain the whole root. Now everything is copied and masked after which the region of interest is extracted.

Not sure when this bug was introduced (I haven't updated this for a very long time, over 4 years…) and it's only quickly tested with my multi-monitor setup.