### PR TITLE
main.py: improve image saving semantics

### DIFF
--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -410,9 +410,17 @@ class Escrotum(gtk.Dialog):
         filetype = "png"
         if "." in self.filename:
             filetype = self.filename.rsplit(".", 1)[1]
+            if filetype == "jpg":
+                filetype = "jpeg"
+
+        optskeys = []
+        optsvalues = []
+        if filetype != "png":
+            optskeys.append("quality")
+            optsvalues.append("100")
 
         try:
-            pb.savev(self.filename, filetype, ["quality"], ["100"])
+            pb.savev(self.filename, filetype, optskeys, optsvalues)
             print(self.filename)
         except Exception as error:
             print(error)


### PR DESCRIPTION
Fixes GDK Pixbuf warning for providing illegal quality option to the PNG saver
also allows saving of JPEG files with the jpg extension