### PR TITLE
Fix #68: Broken after upgrade to python 3.9

### DIFF
--- a/escrotum/util.py
+++ b/escrotum/util.py
@@ -113,7 +113,7 @@ def bgra2rgba(pixels, width, height):
             for y in range (height):
                 i = (width * y + x) * 4
                 data[i + 0], data[i + 2] = data[i + 2], data[i + 0]
-    return data.tostring()
+    return data.tobytes()
 
 
 def cmd_exists(cmd):


### PR DESCRIPTION
With Python 3.2 `array.tostring()` was deprecated and renamed to
`array.tobytes()`. Now, with Python 3.9, `array.tostring()` was finally
removed.