### PR TITLE
change the pixbuf settings to not apply during default (png) creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 escrotum.egg-info
 build/
 dist/
+venv/

--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -415,9 +415,6 @@ class Escrotum(gtk.Dialog):
 
         optskeys = []
         optsvalues = []
-        if filetype != "png":
-            optskeys.append("quality")
-            optsvalues.append("100")
 
         try:
             pb.savev(self.filename, filetype, optskeys, optsvalues)

--- a/escrotum/main.py
+++ b/escrotum/main.py
@@ -415,6 +415,9 @@ class Escrotum(gtk.Dialog):
 
         optskeys = []
         optsvalues = []
+        if filetype == "jpg":
+            optskeys.append("quality")
+            optsvalues.append("100")
 
         try:
             pb.savev(self.filename, filetype, optskeys, optsvalues)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="escrotum",
-    version="1.0.1",
+    version="1.0.1", # todo: update me
     author='Roger Duran',
     author_email='rogerduran@gmail.com',
     url='https://github.com/Roger/escrotum',


### PR DESCRIPTION
Fix the "unrecognized option" error message that was being sent for png creation. Still apply the quality parameter during jpeg/jpg creation.

#70 